### PR TITLE
Update two verification subagents to gpt-4.1

### DIFF
--- a/src/verification/subAgents/citationQualityAgent.ts
+++ b/src/verification/subAgents/citationQualityAgent.ts
@@ -3,7 +3,7 @@ import { SubAgentResult } from '../issueSchemas'
 
 export const citationQualityAgent = new Agent({
   name: 'CitationQualityAgent',
-  model: 'o4-mini',
+  model: 'gpt-4.1',
   instructions: `Review every citation for proper Bluebook format and completeness. Verify case names, reporter details, and pincites. Suggest corrections for any citation errors. Use web search as needed to confirm authority details.`,
   tools: [webSearchTool()],
   outputType: SubAgentResult,

--- a/src/verification/subAgents/legalAccuracyAgent.ts
+++ b/src/verification/subAgents/legalAccuracyAgent.ts
@@ -3,7 +3,7 @@ import { SubAgentResult } from '../issueSchemas'
 
 export const legalAccuracyAgent = new Agent({
   name: 'LegalAccuracyAgent',
-  model: 'o4-mini',
+  model: 'gpt-4.1',
   instructions: `You check the memo for legal accuracy and current law. Verify all statutes, regulations, and cases cited. Flag outdated or incorrect statements and suggest precise fixes. Use web search to confirm authorities.`,
   tools: [webSearchTool()],
   outputType: SubAgentResult,


### PR DESCRIPTION
## Summary
- use `gpt-4.1` model for `legalAccuracyAgent`
- use `gpt-4.1` model for `citationQualityAgent`
- run `npm run lint` (fails due to existing lint errors)

## Testing
- `npm run lint > /tmp/lint.log 2>&1 && tail -n 20 /tmp/lint.log`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685471866c9c8326b135101784fc9129